### PR TITLE
[DEMO] Update shellcheck-orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ orbs:
         description: |
           This is a docker image that contains the `shellcheck` binary.
         docker:
-          - image: koalaman/shellcheck-alpine:v0.6.0
+          - image: koalaman/shellcheck-alpine:v0.7.0
 
     examples:
       shellcheck-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,134 @@
+version: 2.1
+description: This is a test of a shellcheck-orb patch.
+
+orbs:
+  # copied from https://github.com/CircleCI-Public/shellcheck-orb/blob/b768ac580b34f3f1e73b531ac705c49789df5af7/src/%40orb.yml
+  shellcheck:
+    description: |
+      ShellCheck, a static analysis tool for shell scripts
+      https://shellcheck.net Check all scripts in your repository using
+      `shellcheck` on every commit. This orb's source is available here:
+      https://github.com/CircleCI-Public/shellcheck-orb
+    executors:
+      shellcheck:
+        description: |
+          This is a docker image that contains the `shellcheck` binary.
+        docker:
+          - image: koalaman/shellcheck-alpine:v0.6.0
+
+    examples:
+      shellcheck-workflow:
+        description: |
+          Checkout and run shellcheck against all files with the extension .sh
+        usage:
+          version: 2.1
+
+          orbs:
+            shellcheck: circleci/shellcheck@x.y.z
+
+          workflows:
+            shellcheck:
+              jobs:
+                - shellcheck/check
+
+      exclude-path:
+        description: |
+          Exclude subdirectory 'foo' and its contents
+        usage:
+          version: 2.1
+
+          orbs:
+            shellcheck: circleci/shellcheck@x.y.z
+
+          workflows:
+            shellcheck:
+              jobs:
+                - shellcheck/check:
+                    exclude: './foo/*'
+
+      custom-executor:
+        description: |
+          Use custom executor
+        usage:
+          version: 2.1
+
+          orbs:
+            shellcheck: circleci/shellcheck@x.y.z
+
+          executors:
+            my-custom-executor:
+              docker:
+                - image: nlknguyen/alpine-shellcheck:v0.4.6
+
+          workflows:
+            shellcheck:
+              jobs:
+                - shellcheck/check:
+                    executor: my-custom-executor
+
+    jobs:
+      check:
+        description: |
+          Run shellcheck over any shell scripts in the respository.
+          Add this job to any workflow to automatically check any shell scripts
+          in your repository.
+        executor: << parameters.executor >>
+        parameters:
+          exclude:
+            type: string
+            default: ""
+            description: |
+              This file pattern (as passed to `find -not -path`) is used to select
+              a path to exclude when searching for files. Currently, this is
+              limited to a single pattern.
+          ignore:
+            type: string
+            default: ""
+            description: >
+              Comma-separated string list of error types to ignore, e.g.,
+              `SC2059,SC2034,SC1090`
+          path:
+            type: string
+            default: .
+            description: The top-most directory to search for files in.
+          pattern:
+            type: string
+            default: "*.sh"
+            description: |
+              The file pattern as passed to `find` to locate shell scripts.
+          output:
+            type: string
+            default: shellcheck.log
+            description: |
+              The filename of the shellcheck output, which is automatically saved
+              as a job artifact.
+          executor:
+            type: executor
+            default: shellcheck
+            description: |
+              Override executor with a custom executor, for example, to choose a
+              different version tag.
+        steps:
+          - checkout
+          - run:
+              name: Check Scripts
+              command: |
+                <<#parameters.ignore>>
+                IGNORE_STRING=<<parameters.ignore>>
+                SHELLCHECK_OPTS=$(echo "-e ${IGNORE_STRING//,/ -e }")
+                export SHELLCHECK_OPTS="$SHELLCHECK_OPTS"
+                echo "Running shellcheck with the following SHELLCHECK_OPTS value..."
+                echo "SHELLCHECK_OPTS=$SHELLCHECK_OPTS"
+                <</parameters.ignore>>
+                find '<<parameters.path>>' -not -path '<<parameters.exclude>>' \
+                  -type f -name '<<parameters.pattern>>' | \
+                  xargs shellcheck --external-sources | \
+                  tee -a '<<parameters.output>>'
+          - store_artifacts:
+              path: '<< parameters.output >>'
+              destination: shellcheck
+
+workflows:
+  shellcheck:
+    jobs:
+      - shellcheck/check

--- a/example.sh
+++ b/example.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 for file in rc.d/*
 do
-     exec "$file"
+     echo "$file"
 done
 
 # copied from https://github.com/koalaman/shellcheck/issues/1340

--- a/example.sh
+++ b/example.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+for file in rc.d/*
+do
+     exec "$file"
+done
+
+# copied from https://github.com/koalaman/shellcheck/issues/1340


### PR DESCRIPTION
- d3cff46: Add the original shellcheck-orb as an inline orb and run shellcheck on `example.sh`
    - `example.sh` has a flaw that shellcheck 0.7.0 points out but shellcheck 0.6.0 won't.
    - [CI passes](https://circleci.com/gh/vzvu3k6k/Spoon-Knife/12) as expected.
- b588fdd: Update shellcheck from 0.6.0 to 0.7.0
    - [CI fails](https://circleci.com/gh/vzvu3k6k/Spoon-Knife/13) as expected.
- 30e9375: Fix flaw in `example.sh`
    - [CI passes](https://circleci.com/gh/vzvu3k6k/Spoon-Knife/14) as expected.